### PR TITLE
Pit Scout Changes

### DIFF
--- a/integrated-scouting-apps/src/routes/login.tsx
+++ b/integrated-scouting-apps/src/routes/login.tsx
@@ -77,8 +77,8 @@ function LoginPage(props: any) {
 				}
 				catch (err) {
 					console.log(err);
-					window.alert("Error occured, please do not do leave this message and notify a Webdev member immediately.");
-					window.alert(err);
+					// window.alert("Error occured, please do not do leave this message and notify a Webdev member immediately.");
+					// window.alert(err);
 				}
 			}}>
 				<h2 style={{ color: "red" }}>{msg}</h2>

--- a/integrated-scouting-apps/src/routes/pit.tsx
+++ b/integrated-scouting-apps/src/routes/pit.tsx
@@ -262,11 +262,11 @@ function PitScout(props: any) {
           <InputNumber 
             controls 
             min={1} 
-           max={9999} 
+           max={99999} 
            className="input"
            onChange={(value) => {
               if (value !== null) {
-               const limitedValue = Math.min(9999, value);
+               const limitedValue = Math.min(99999, value);
                 getPitScout(limitedValue);
               }
             }}

--- a/integrated-scouting-apps/src/routes/pit.tsx
+++ b/integrated-scouting-apps/src/routes/pit.tsx
@@ -103,7 +103,7 @@ function PitScout(props: any) {
       "robot_motor_type": event.robot_motor_type,
       "robot_motor_counter": event.robot_motor_counter,
       "robot_wheel_type": event.robot_wheel_type,
-      "robot_intake_capability": event.robot_intake_capability,
+      "robot_coral_intake_capability": event.robot_coral_intake_capability,
       "robot_shooting_capability": event.robot_shooting_capability,
       "robot_ability_score_l1": event.robot_ability_ability_l1,
       "robot_ability_score_l2": event.robot_ability_ability_l2,
@@ -129,7 +129,7 @@ function PitScout(props: any) {
       "robot_drive_train": "test",
       "robot_events": -1,
       "robot_GP": -1,
-      "robot_intake_capability": "test",
+      "robot_coral_intake_capability": "test",
       "robot_motor_counter": -1,
       "robot_motor_type": "test",
       "robot_pit_organization": -1,
@@ -187,7 +187,7 @@ function PitScout(props: any) {
       robot_motor_type: string;
       robot_motor_counter: number;
       robot_wheel_type: string;
-      robot_intake_capability: string;
+      robot_coral_intake_capability: string;
       robot_shooting_capability: string;
       robot_ability_score_l1: boolean;
       robot_ability_score_l2: boolean;
@@ -224,22 +224,27 @@ function PitScout(props: any) {
       { label: "Mechanum", value: 'mechanum' },
       { label: "Other", value: 'other' },
     ];
-    const intakeCap = [
-      { label: "Source", value: "source" },
+    const coralIntakeCap = [
+      { label: "Coral Station", value: "coral_station" },
       { label: "Ground", value: "ground" },
       { label: "Both", value: 'both' },
       { label: "None", value: 'none' },
     ];
+    const algaeIntakeCap = [
+      { label: "Net", value: "net" },
+      { label: "Processor", value: "processor" },
+      { label: "Both", value: 'both' },
+      { label: "None", value: 'none' },
+    ];
     const shootingCap = [
-      { label: "Algae", value: "algae" },
-      { label: "Coral", value: "coral" },
+      { label: "Reef Zone", value: "reef zone" },
+      { label: "Ground", value: "ground" },
       { label: "Both", value: 'both' },
       { label: "None", value: 'none' },
     ];
     const climbingCap = [
       { label: "Shallow", value: "shallow" },
       { label: "Deep", value: "deep" },
-      { label: "Parked", value: 'parked' },
       { label: "None", value: "none" }
     ];
     return (
@@ -275,11 +280,7 @@ function PitScout(props: any) {
             }}
           />
         </Form.Item>
-        <h2>Drive Train Type</h2>
-        <Form.Item<FieldType> name="robot_drive_train" rules={[{ required: true, message: 'Please input the drive train type!' }]}>
-          <Select options={drive_train} className="input" />
-        </Form.Item>
-        <h2>Robot Weight</h2>
+        <h2>Robot Weight (lbs)</h2>
         <Form.Item<FieldType> 
           name="robot_weight" 
           rules={[{ required: true, message: 'Please input the robot weight in lbs!' }]}>
@@ -291,6 +292,10 @@ function PitScout(props: any) {
           className="input" 
           type="number"
         />
+        </Form.Item>
+        <h2>Drive Train Type</h2>
+        <Form.Item<FieldType> name="robot_drive_train" rules={[{ required: true, message: 'Please input the drive train type!' }]}>
+          <Select options={drive_train} className="input" />
         </Form.Item>
         <h2>Motor Type</h2>
         <Form.Item<FieldType> name="robot_motor_type" rules={[{ required: true, message: 'Please input the motor type!' }]}>
@@ -317,13 +322,9 @@ function PitScout(props: any) {
         <Form.Item<FieldType> name="robot_wheel_type" rules={[{ required: true, message: 'Please input the wheel type!' }]}>
           <Select placeholder="" options={wheel_type} className="input" />
         </Form.Item>
-        <h2>Intake Capability</h2>
-        <Form.Item<FieldType> name="robot_intake_capability" rules={[{ required: true, message: 'Please input the intake capability!' }]}>
-          <Select options={intakeCap} className="input" />
-        </Form.Item>
-        <h2>Shooting Capability</h2>
-        <Form.Item<FieldType> name="robot_shooting_capability" rules={[{ required: true, message: 'Please input the shooting capability!' }]}>
-          <Select options={shootingCap} className="input" />
+        <h2>Coral Intake Capability</h2>
+        <Form.Item<FieldType> name="robot_coral_intake_capability" rules={[{ required: true, message: 'Please input the intake capability!' }]}>
+          <Select options={coralIntakeCap} className="input" />
         </Form.Item>
         <h2>Coral Scoring</h2>
         <h2> L1 </h2>
@@ -341,6 +342,14 @@ function PitScout(props: any) {
         <h2> L4 </h2>
         <Form.Item<FieldType> valuePropName="checked" name="robot_ability_score_l4">
           <Checkbox className='input_checkbox' />
+        </Form.Item>
+        <h2>Algae Intake Capability</h2>
+        <Form.Item<FieldType> name="robot_shooting_capability" rules={[{ required: true, message: 'Please input the shooting capability!' }]}>
+          <Select options={shootingCap} className="input" />
+        </Form.Item>
+        <h2>Algae Scoring Capability</h2>
+        <Form.Item<FieldType> name="robot_shooting_capability" rules={[{ required: true, message: 'Please input the shooting capability!' }]}>
+          <Select options={algaeIntakeCap} className="input" />
         </Form.Item>
         <h2>Climbing Capability</h2>
         <Form.Item<FieldType> name="robot_climbing_capabilities" rules={[{ required: true, message: 'Please input the climbing capability!' }]}>

--- a/integrated-scouting-apps/src/routes/pit.tsx
+++ b/integrated-scouting-apps/src/routes/pit.tsx
@@ -292,78 +292,107 @@ function PitScout(props: any) {
         <h2>Climbing Capability</h2>
         <Form.Item<FieldType> name="robot_climbing_capabilities" rules={[{ required: true, message: 'Please input the climbing capability!' }]}>
           <Select options={climbingCap} className="input" />
-        </Form.Item>
-        <h2>Pit Organization (0-4)</h2>
-        <Form.Item<FieldType> name="robot_pit_organization" rules={[{ required: true, message: 'Please input the pit organization rating!' }]}>
-          <InputNumber
-            controls
-            disabled
-            min={0}
-            max={4}
-            className="input"
-            addonAfter={<Button onClick={() => {
-              setFormValue({ ...formValue, robot_pit_organization: formValue.robot_pit_organization + 1 });
-            }} className='incrementbutton'>+</Button>}
-            addonBefore={<Button onClick={() => {
-              if (Number(formValue.robot_pit_organization) > 0) {
-                setFormValue({ ...formValue, robot_pit_organization: formValue.robot_pit_organization - 1 });
-              }
-            }} className='decrementbutton'>-</Button>}
-          />
-        </Form.Item>
-        <h2>Team Safety (0-4)</h2>
-        <Form.Item<FieldType> name="robot_team_safety" rules={[{ required: true, message: 'Please input the team safety rating!' }]}>
-          <InputNumber
-            controls
-            disabled
-            min={0}
-            max={4}
-            className="input"
-            addonAfter={<Button onClick={() => {
-              setFormValue({ ...formValue, robot_team_safety: formValue.robot_team_safety + 1 });
-            }} className='incrementbutton'>+</Button>}
-            addonBefore={<Button onClick={() => {
-              if (Number(formValue.robot_team_safety) > 0) {
-                setFormValue({ ...formValue, robot_team_safety: formValue.robot_team_safety - 1 });
-              }
-            }} className='decrementbutton'>-</Button>}
-          />
-        </Form.Item>
-        <h2>Team Workmanship (0-4)</h2>
-        <Form.Item<FieldType> name="robot_team_workmanship" rules={[{ required: true, message: 'Please input the team workmanship rating!' }]}>
-          <InputNumber
-            controls
-            disabled
-            min={0}
-            max={4}
-            className="input"
-            addonAfter={<Button onClick={() => {
-              setFormValue({ ...formValue, robot_team_workmanship: formValue.robot_team_workmanship + 1 });
-            }} className='incrementbutton'>+</Button>}
-            addonBefore={<Button onClick={() => {
-              if (Number(formValue.robot_team_workmanship) > 0) {
-                setFormValue({ ...formValue, robot_team_workmanship: formValue.robot_team_workmanship - 1 });
-              }
-            }} className='decrementbutton'>-</Button>}
-          />
-        </Form.Item>
-        <h2>Gracious Professionalism (0-4)</h2>
-        <Form.Item<FieldType> name="robot_GP" rules={[{ required: true, message: 'Please input the GP rating!' }]}>
-          <InputNumber
-            controls
-            disabled
-            min={0}
-            max={4}
-            className="input"
-            addonAfter={<Button onClick={() => {
-              setFormValue({ ...formValue, robot_GP: formValue.robot_GP + 1 });
-            }} className='incrementbutton'>+</Button>}
-            addonBefore={<Button onClick={() => {
-              if (Number(formValue.robot_GP) > 0) {
-                setFormValue({ ...formValue, robot_GP: formValue.robot_GP - 1 });
-              }
-            }} className='decrementbutton'>-</Button>}
-          />
+       
+        <Form.Item>
+            <h2>Pit Organization(0-4)</h2>
+          <Form.Item<FieldType> name="robot_pit_organization" rules={[{ required: true, message: 'Please input the pit organization rating!' }]}>
+            <InputNumber
+                  controls
+                  disabled
+                  min={0}
+                  max={4}
+                  className="input"
+                addonAfter={<Button onClick={() => {
+                  setFormValue(prevValue => ({
+                    ...prevValue,
+                    robot_pit_organization: Math.min(4, (prevValue.robot_pit_organization || 0) + 1)
+                }));
+              }} className='incrementbutton'>+</Button>}
+              addonBefore={<Button onClick={() => {
+                setFormValue(prevValue => ({
+                    ...prevValue,
+                    robot_pit_organization: Math.max(0, (prevValue.robot_pit_organization || 0) - 1)
+                  }));
+              }} className='decrementbutton'>-</Button>}
+            />
+          </Form.Item>
+          </Form.Item>
+
+          <Form.Item>
+            <h2>Team Safety(0-4)</h2>
+          <Form.Item<FieldType> name="robot_team_safety" rules={[{ required: true, message: 'Please input the team safety rating!' }]}>
+            <InputNumber
+                  controls
+                  disabled
+                  min={0}
+                  max={4}
+                  className="input"
+                addonAfter={<Button onClick={() => {
+                  setFormValue(prevValue => ({
+                    ...prevValue,
+                    robot_team_safety: Math.min(4, (prevValue.robot_team_safety || 0) + 1)
+                }));
+              }} className='incrementbutton'>+</Button>}
+              addonBefore={<Button onClick={() => {
+                setFormValue(prevValue => ({
+                    ...prevValue,
+                    robot_team_safety: Math.max(0, (prevValue.robot_team_safety || 0) - 1)
+                  }));
+              }} className='decrementbutton'>-</Button>}
+            />
+          </Form.Item>
+          </Form.Item>
+        
+          <Form.Item>
+            <h2>Team Workmanship(0-4)</h2>
+          <Form.Item<FieldType> name="robot_team_workmanship" rules={[{ required: true, message: 'Please input the team workmanship rating!' }]}>
+            <InputNumber
+                  controls
+                  disabled
+                  min={0}
+                  max={4}
+                  className="input"
+                addonAfter={<Button onClick={() => {
+                  setFormValue(prevValue => ({
+                    ...prevValue,
+                    robot_team_workmanship: Math.min(4, (prevValue.robot_team_workmanship || 0) + 1)
+                }));
+              }} className='incrementbutton'>+</Button>}
+              addonBefore={<Button onClick={() => {
+                setFormValue(prevValue => ({
+                    ...prevValue,
+                    robot_team_workmanship: Math.max(0, (prevValue.robot_team_workmanship || 0) - 1)
+                  }));
+              }} className='decrementbutton'>-</Button>}
+            />
+          </Form.Item>
+          </Form.Item>
+
+          <Form.Item>
+            <h2>Gracious Professionalism(0-4)</h2>
+          <Form.Item<FieldType> name="robot_GP" rules={[{ required: true, message: 'Please input the GP rating!' }]}>
+            <InputNumber
+                  controls
+                  disabled
+                  min={0}
+                  max={4}
+                  className="input"
+                addonAfter={<Button onClick={() => {
+                  setFormValue(prevValue => ({
+                    ...prevValue,
+                    robot_GP: Math.min(4, (prevValue.robot_GP || 0) + 1)
+                }));
+              }} className='incrementbutton'>+</Button>}
+              addonBefore={<Button onClick={() => {
+                setFormValue(prevValue => ({
+                    ...prevValue,
+                    robot_GP: Math.max(0, (prevValue.robot_GP || 0) - 1)
+                  }));
+              }} className='decrementbutton'>-</Button>}
+            />
+          </Form.Item>
+          </Form.Item>
+
         </Form.Item>
         <h2>Comments</h2>
         <Form.Item<FieldType> name="comments" rules={[{ required: true, message: "Please input some comments!" }]}>

--- a/integrated-scouting-apps/src/routes/pit.tsx
+++ b/integrated-scouting-apps/src/routes/pit.tsx
@@ -230,15 +230,15 @@ function PitScout(props: any) {
       { label: "Both", value: 'both' },
       { label: "None", value: 'none' },
     ];
-    const algaeIntakeCap = [
-      { label: "Net", value: "net" },
-      { label: "Processor", value: "processor" },
+    const algaeintakeCap = [
+      { label: "Reef Zone", value: "reef zone" },
+      { label: "Coral", value: "coral" },
       { label: "Both", value: 'both' },
       { label: "None", value: 'none' },
     ];
-    const shootingCap = [
-      { label: "Reef Zone", value: "reef zone" },
-      { label: "Ground", value: "ground" },
+    const algaescoringCap = [
+      { label: "Net", value: "net" },
+      { label: "Processor", value: "processor" },
       { label: "Both", value: 'both' },
       { label: "None", value: 'none' },
     ];
@@ -294,12 +294,22 @@ function PitScout(props: any) {
         />
         </Form.Item>
         <h2>Drive Train Type</h2>
-        <Form.Item<FieldType> name="robot_drive_train" rules={[{ required: true, message: 'Please input the drive train type!' }]}>
-          <Select options={drive_train} className="input" />
+        <Form.Item name="robot_drive_train" rules={[{ required: true, message: 'Please input the drive train type!' }]}>
+        <Select
+          options={drive_train}
+          className="input"
+          dropdownMatchSelectWidth={false}
+          dropdownStyle={{ maxHeight: 'none' }}
+        />
         </Form.Item>
         <h2>Motor Type</h2>
-        <Form.Item<FieldType> name="robot_motor_type" rules={[{ required: true, message: 'Please input the motor type!' }]}>
-          <Select options={motor_type} className="input" />
+        <Form.Item name="robot_motor_type" rules={[{ required: true, message: 'Please input the motor type!' }]}>
+        <Select
+          options={motor_type}
+          className="input"
+          dropdownMatchSelectWidth={false}
+          dropdownStyle={{ maxHeight: 'none' }}
+        />
         </Form.Item>
         <h2># of Motors</h2>
         <Form.Item<FieldType> name="robot_motor_counter" rules={[{ required: true, message: 'Please input the number of motors!' }]}>
@@ -319,12 +329,23 @@ function PitScout(props: any) {
           />
         </Form.Item>
         <h2>Wheel Type</h2>
-        <Form.Item<FieldType> name="robot_wheel_type" rules={[{ required: true, message: 'Please input the wheel type!' }]}>
-          <Select placeholder="" options={wheel_type} className="input" />
+        <Form.Item name="robot_wheel_type" rules={[{ required: true, message: 'Please input the wheel type!' }]}>
+        <Select
+          placeholder=""
+          options={wheel_type}
+          className="input"
+          dropdownMatchSelectWidth={false}
+          dropdownStyle={{ maxHeight: 'none' }}
+        />
         </Form.Item>
         <h2>Coral Intake Capability</h2>
-        <Form.Item<FieldType> name="robot_coral_intake_capability" rules={[{ required: true, message: 'Please input the intake capability!' }]}>
-          <Select options={coralIntakeCap} className="input" />
+          <Form.Item name="robot_coral_intake_capability" rules={[{ required: true, message: 'Please input the intake capability!' }]}>
+          <Select
+            options={coralIntakeCap}
+            className="input"
+            dropdownMatchSelectWidth={false}
+            dropdownStyle={{ maxHeight: 'none' }}
+          />
         </Form.Item>
         <h2>Coral Scoring</h2>
         <h2> L1 </h2>
@@ -344,17 +365,26 @@ function PitScout(props: any) {
           <Checkbox className='input_checkbox' />
         </Form.Item>
         <h2>Algae Intake Capability</h2>
-        <Form.Item<FieldType> name="robot_shooting_capability" rules={[{ required: true, message: 'Please input the shooting capability!' }]}>
-          <Select options={shootingCap} className="input" />
-        </Form.Item>
+              <Form.Item name="robot_shooting_capability" rules={[{ required: true, message: 'Please input the shooting capability!' }]}>
+        <Select
+          options={algaeintakeCap}
+          className="input"
+          dropdownMatchSelectWidth={false}
+          dropdownStyle={{ maxHeight: 'none' }}
+        />
+      </Form.Item>
         <h2>Algae Scoring Capability</h2>
-        <Form.Item<FieldType> name="robot_shooting_capability" rules={[{ required: true, message: 'Please input the shooting capability!' }]}>
-          <Select options={algaeIntakeCap} className="input" />
-        </Form.Item>
+              <Form.Item name="robot_shooting_capability" rules={[{ required: true, message: 'Please input the shooting capability!' }]}>
+        <Select
+          options={algaescoringCap}
+          className="input"
+          dropdownMatchSelectWidth={false}
+          dropdownStyle={{ maxHeight: 'none' }}
+        />
+      </Form.Item>
         <h2>Climbing Capability</h2>
         <Form.Item<FieldType> name="robot_climbing_capabilities" rules={[{ required: true, message: 'Please input the climbing capability!' }]}>
           <Select options={climbingCap} className="input" />
-       
         <Form.Item>
             <h2>Pit Organization(0-4)</h2>
           <Form.Item<FieldType> name="robot_pit_organization" rules={[{ required: true, message: 'Please input the pit organization rating!' }]}>

--- a/integrated-scouting-apps/src/routes/pit.tsx
+++ b/integrated-scouting-apps/src/routes/pit.tsx
@@ -107,6 +107,8 @@ function PitScout(props: any) {
       "robot_wheel_type": event.robot_wheel_type,
       "robot_coral_intake_capability": event.robot_coral_intake_capability,
       "robot_shooting_capability": event.robot_shooting_capability,
+      "robot_algae_intake_capability": event.robot_algae_intake_capability,
+      "robot_algae_scoring_capability": event.robot_algae_scoring_capability,
       "robot_ability_score_l1": event.robot_ability_ability_l1,
       "robot_ability_score_l2": event.robot_ability_ability_l2,
       "robot_ability_score_l3": event.robot_ability_ability_l3,
@@ -190,7 +192,8 @@ function PitScout(props: any) {
       robot_motor_counter: number;
       robot_wheel_type: string;
       robot_coral_intake_capability: string;
-      robot_shooting_capability: string;
+      robot_algae_intake_capability: string;
+      robot_algae_scoring_capability: string;
       robot_ability_score_l1: boolean;
       robot_ability_score_l2: boolean;
       robot_ability_score_l3: boolean;
@@ -367,7 +370,7 @@ function PitScout(props: any) {
           <Checkbox className='input_checkbox' />
         </Form.Item>
         <h2>Algae Intake Capability</h2>
-              <Form.Item name="robot_shooting_capability" rules={[{ required: true, message: 'Please input the shooting capability!' }]}>
+              <Form.Item name="robot_algae_intake_capability" rules={[{ required: true, message: 'Please input the Algae intake capability!' }]}>
         <Select
           options={algaeintakeCap}
           className="input"
@@ -376,7 +379,7 @@ function PitScout(props: any) {
         />
       </Form.Item>
         <h2>Algae Scoring Capability</h2>
-              <Form.Item name="robot_shooting_capability" rules={[{ required: true, message: 'Please input the shooting capability!' }]}>
+              <Form.Item name="robot_shooting_capability" rules={[{ required: true, message: 'Please input the Algae Scoring capability!' }]}>
         <Select
           options={algaescoringCap}
           className="input"
@@ -391,8 +394,6 @@ function PitScout(props: any) {
             <h2>Pit Organization(0-4)</h2>
           <Form.Item<FieldType> name="robot_pit_organization" rules={[{ required: true, message: 'Please input the pit organization rating!' }]}>
             <InputNumber
-                  controls
-                  disabled
                   min={0}
                   max={4}
                   className="input"
@@ -416,8 +417,6 @@ function PitScout(props: any) {
             <h2>Team Safety(0-4)</h2>
           <Form.Item<FieldType> name="robot_team_safety" rules={[{ required: true, message: 'Please input the team safety rating!' }]}>
             <InputNumber
-                  controls
-                  disabled
                   min={0}
                   max={4}
                   className="input"
@@ -441,8 +440,6 @@ function PitScout(props: any) {
             <h2>Team Workmanship(0-4)</h2>
           <Form.Item<FieldType> name="robot_team_workmanship" rules={[{ required: true, message: 'Please input the team workmanship rating!' }]}>
             <InputNumber
-                  controls
-                  disabled
                   min={0}
                   max={4}
                   className="input"
@@ -466,8 +463,6 @@ function PitScout(props: any) {
             <h2>Gracious Professionalism(0-4)</h2>
           <Form.Item<FieldType> name="robot_GP" rules={[{ required: true, message: 'Please input the GP rating!' }]}>
             <InputNumber
-                  controls
-                  disabled
                   min={0}
                   max={4}
                   className="input"

--- a/integrated-scouting-apps/src/routes/pit.tsx
+++ b/integrated-scouting-apps/src/routes/pit.tsx
@@ -274,7 +274,7 @@ function PitScout(props: any) {
               if (charCode > 31 && (charCode < 48 || charCode > 57)) {
                   event.preventDefault();
               }
-              if (currentValue.length >= 4) {
+              if (currentValue.length >= 5) {
                 event.preventDefault();
               }
             }}

--- a/integrated-scouting-apps/src/routes/pit.tsx
+++ b/integrated-scouting-apps/src/routes/pit.tsx
@@ -112,7 +112,6 @@ function PitScout(props: any) {
       "robot_team_safety": event.robot_team_safety,
       "robot_team_workmanship": event.robot_team_workmanship,
       "robot_GP": event.robot_GP,
-      "robot_auton_path": imageURI.current,
       "images": robotImageURI,
       "comments": event.comments,
     };
@@ -121,8 +120,6 @@ function PitScout(props: any) {
       "images": ["test"],
       "initial": "test",
       "robot_ability_traversed_stage": false,
-      "robot_auton_path": "test",
-      "robot_auton_path_detail": "test",
       "robot_climbing_capabilities": "test",
       "robot_drive_train": "test",
       "robot_events": -1,
@@ -193,7 +190,6 @@ function PitScout(props: any) {
       robot_team_safety: number;
       robot_team_workmanship: number;
       robot_GP: number;
-      robot_auton_path: string;
       robot_images: string;
       comments: string;
     };
@@ -297,23 +293,7 @@ function PitScout(props: any) {
         <Form.Item<FieldType> name="robot_climbing_capabilities" rules={[{ required: true, message: 'Please input the climbing capability!' }]}>
           <Select options={climbingCap} className="input" />
         </Form.Item>
-        <h2>Auton Path</h2>
-        <ReactSketchCanvas
-          ref={canvasRef}
-          strokeWidth={8}
-          height='882px'
-          strokeColor='#32a7dc'
-          backgroundImage={field_blue}
-          exportWithBackgroundImage
-          svgStyle={{ width: '882px', height: '882px' }}
-          style={{ marginBottom: '5%' }}
-        />
-        <Flex justify='in-between' style={{ marginBottom: '5%' }}>
-          <Button onClick={() => canvasRef.current?.undo()} className='pathbutton'>Undo</Button>
-          <Button onClick={() => canvasRef.current?.redo()} className='pathbutton'>Redo</Button>
-          <Button onClick={() => canvasRef.current?.clearCanvas()} className='pathbutton'>Clear</Button>
-        </Flex>
-        <h2>Pit Organization</h2>
+        <h2>Pit Organization (0-4)</h2>
         <Form.Item<FieldType> name="robot_pit_organization" rules={[{ required: true, message: 'Please input the pit organization rating!' }]}>
           <InputNumber
             controls
@@ -331,7 +311,7 @@ function PitScout(props: any) {
             }} className='decrementbutton'>-</Button>}
           />
         </Form.Item>
-        <h2>Team Safety</h2>
+        <h2>Team Safety (0-4)</h2>
         <Form.Item<FieldType> name="robot_team_safety" rules={[{ required: true, message: 'Please input the team safety rating!' }]}>
           <InputNumber
             controls
@@ -349,7 +329,7 @@ function PitScout(props: any) {
             }} className='decrementbutton'>-</Button>}
           />
         </Form.Item>
-        <h2>Team Workmanship</h2>
+        <h2>Team Workmanship (0-4)</h2>
         <Form.Item<FieldType> name="robot_team_workmanship" rules={[{ required: true, message: 'Please input the team workmanship rating!' }]}>
           <InputNumber
             controls

--- a/integrated-scouting-apps/src/routes/pit.tsx
+++ b/integrated-scouting-apps/src/routes/pit.tsx
@@ -2,7 +2,7 @@ import '../public/stylesheets/style.css';
 import '../public/stylesheets/pit.css';
 import '../public/stylesheets/match.css';
 import logo from '../public/images/logo.png';
-import { Checkbox, Flex, Form, Input, InputNumber, Select, Upload } from 'antd';
+import { Checkbox, Form, Input, InputNumber, Select, Upload } from 'antd';
 import { useRef } from 'react';
 import { Button } from 'antd';
 import React, { useState, useEffect } from 'react';
@@ -106,7 +106,6 @@ function PitScout(props: any) {
       "robot_motor_counter": event.robot_motor_counter,
       "robot_wheel_type": event.robot_wheel_type,
       "robot_coral_intake_capability": event.robot_coral_intake_capability,
-      "robot_shooting_capability": event.robot_shooting_capability,
       "robot_algae_intake_capability": event.robot_algae_intake_capability,
       "robot_algae_scoring_capability": event.robot_algae_scoring_capability,
       "robot_ability_score_l1": event.robot_ability_ability_l1,
@@ -137,7 +136,6 @@ function PitScout(props: any) {
       "robot_motor_counter": -1,
       "robot_motor_type": "test",
       "robot_pit_organization": -1,
-      "robot_shooting_capability": "test",
       "robot_team_safety": -1,
       "robot_team_workmanship": -1,
       "robot_weight": -1,
@@ -298,6 +296,7 @@ function PitScout(props: any) {
           type="number"
         />
         </Form.Item>
+
         <h2>Drive Train Type</h2>
         <Form.Item name="robot_drive_train" rules={[{ required: true, message: 'Please input the drive train type!' }]}>
         <Select
@@ -379,7 +378,7 @@ function PitScout(props: any) {
         />
       </Form.Item>
         <h2>Algae Scoring Capability</h2>
-              <Form.Item name="robot_shooting_capability" rules={[{ required: true, message: 'Please input the Algae Scoring capability!' }]}>
+              <Form.Item name="robot_algae_scoring_capability" rules={[{ required: true, message: 'Please input the Algae Scoring capability!' }]}>
         <Select
           options={algaescoringCap}
           className="input"
@@ -390,6 +389,8 @@ function PitScout(props: any) {
         <h2>Climbing Capability</h2>
         <Form.Item<FieldType> name="robot_climbing_capabilities" rules={[{ required: true, message: 'Please input the climbing capability!' }]}>
           <Select options={climbingCap} className="input" />
+        </Form.Item>
+
         <Form.Item>
             <h2>Pit Organization(0-4)</h2>
           <Form.Item<FieldType> name="robot_pit_organization" rules={[{ required: true, message: 'Please input the pit organization rating!' }]}>
@@ -410,7 +411,6 @@ function PitScout(props: any) {
                   }));
               }} className='decrementbutton'>-</Button>}
             />
-          </Form.Item>
           </Form.Item>
 
           <Form.Item>
@@ -551,16 +551,16 @@ function PitScout(props: any) {
             const initials = form.getFieldValue("scouter_initial");
             form.resetFields();
             form.setFieldsValue({ "scouter_initial": initials });
-            setFormValue({
-              robot_events: 0,
-              robot_weight: 0,
-              robot_motor_counter: 0,
-              robot_pit_organization: 0,
-              robot_team_safety: 0,
-              robot_team_workmanship: 0,
-              robot_GP: 0,
-              comments: "",
-            });
+            // setFormValue({
+            //   robot_events: 0,
+            //   robot_weight: 0,
+            //   robot_motor_counter: 0,
+            //   robot_pit_organization: 0,
+            //   robot_team_safety: 0,
+            //   robot_team_workmanship: 0,
+            //   robot_GP: 0,
+            //   comments: "",
+            // });
           }
           catch (err) {
             console.log(err);

--- a/integrated-scouting-apps/src/routes/pit.tsx
+++ b/integrated-scouting-apps/src/routes/pit.tsx
@@ -250,8 +250,31 @@ function PitScout(props: any) {
           <Input maxLength={2} className="input" />
         </Form.Item>
         <h2>Team #</h2>
-        <Form.Item<FieldType> name="team_number" rules={[{ required: true, message: 'Please input the team number!' }]}>
-          <InputNumber controls min={1} max={9999} className="input" onChange={(event) => {getPitScout(event as number)}} />
+        <Form.Item<FieldType> 
+          name="team_number" 
+          rules={[{ required: true, message: 'Please input the team number!' }]}>
+          <InputNumber 
+            controls 
+            min={1} 
+           max={9999} 
+           className="input"
+           onChange={(value) => {
+              if (value !== null) {
+               const limitedValue = Math.min(9999, value);
+                getPitScout(limitedValue);
+              }
+            }}
+            onKeyPress={(event) => {
+              const currentValue = event.currentTarget.value;
+              const charCode = event.which ? event.which : event.keyCode;
+              if (charCode > 31 && (charCode < 48 || charCode > 57)) {
+                  event.preventDefault();
+              }
+              if (currentValue.length >= 4) {
+                event.preventDefault();
+              }
+            }}
+          />
         </Form.Item>
         <h2>Drive Train Type</h2>
         <Form.Item<FieldType> name="robot_drive_train" rules={[{ required: true, message: 'Please input the drive train type!' }]}>

--- a/integrated-scouting-apps/src/routes/pit.tsx
+++ b/integrated-scouting-apps/src/routes/pit.tsx
@@ -1,7 +1,6 @@
 import '../public/stylesheets/style.css';
 import '../public/stylesheets/pit.css';
 import '../public/stylesheets/match.css';
-import field_blue from '../public/images/field_blue.png';
 import logo from '../public/images/logo.png';
 import { Checkbox, Flex, Form, Input, InputNumber, Select, Upload } from 'antd';
 import { useRef } from 'react';
@@ -281,8 +280,17 @@ function PitScout(props: any) {
           <Select options={drive_train} className="input" />
         </Form.Item>
         <h2>Robot Weight</h2>
-        <Form.Item<FieldType> name="robot_weight" rules={[{ required: true, message: 'Please input the robot weight in lbs!' }]}>
-          <InputNumber controls className="input" />
+        <Form.Item<FieldType> 
+          name="robot_weight" 
+          rules={[{ required: true, message: 'Please input the robot weight in lbs!' }]}>
+        <InputNumber 
+          min={0} 
+          max={1000}
+          step={1} 
+          controls 
+          className="input" 
+          type="number"
+        />
         </Form.Item>
         <h2>Motor Type</h2>
         <Form.Item<FieldType> name="robot_motor_type" rules={[{ required: true, message: 'Please input the motor type!' }]}>

--- a/integrated-scouting-apps/src/routes/pit.tsx
+++ b/integrated-scouting-apps/src/routes/pit.tsx
@@ -106,7 +106,10 @@ function PitScout(props: any) {
       "robot_wheel_type": event.robot_wheel_type,
       "robot_intake_capability": event.robot_intake_capability,
       "robot_shooting_capability": event.robot_shooting_capability,
-      "robot_ability_traversed_stage": event.robot_ability_traversed_stage,
+      "robot_ability_score_l1": event.robot_ability_ability_l1,
+      "robot_ability_score_l2": event.robot_ability_ability_l2,
+      "robot_ability_score_l3": event.robot_ability_ability_l3,
+      "robot_ability_score_l4": event.robot_ability_ability_l4,
       "robot_climbing_capabilities": event.robot_climbing_capabilities,
       "robot_pit_organization": event.robot_pit_organization,
       "robot_team_safety": event.robot_team_safety,
@@ -119,7 +122,10 @@ function PitScout(props: any) {
     const TESTDONOTREMOVE = {
       "images": ["test"],
       "initial": "test",
-      "robot_ability_traversed_stage": false,
+      "robot_ability_score_l1": false,
+      "robot_ability_score_l2": false,
+      "robot_ability_score_l3": false,
+      "robot_ability_score_l4": false,
       "robot_climbing_capabilities": "test",
       "robot_drive_train": "test",
       "robot_events": -1,
@@ -184,7 +190,10 @@ function PitScout(props: any) {
       robot_wheel_type: string;
       robot_intake_capability: string;
       robot_shooting_capability: string;
-      robot_ability_traversed_stage: boolean;
+      robot_ability_score_l1: boolean;
+      robot_ability_score_l2: boolean;
+      robot_ability_score_l3: boolean;
+      robot_ability_score_l4: boolean;
       robot_climbing_capabilities: string;
       robot_pit_organization: number;
       robot_team_safety: number;
@@ -285,8 +294,21 @@ function PitScout(props: any) {
         <Form.Item<FieldType> name="robot_shooting_capability" rules={[{ required: true, message: 'Please input the shooting capability!' }]}>
           <Select options={shootingCap} className="input" />
         </Form.Item>
-        <h2>Under Stage</h2>
-        <Form.Item<FieldType> valuePropName="checked" name="robot_ability_traversed_stage">
+        <h2>Coral Scoring</h2>
+        <h2> L1 </h2>
+        <Form.Item<FieldType> valuePropName="checked" name="robot_ability_score_l1">
+          <Checkbox className='input_checkbox' />
+        </Form.Item>
+        <h2> L2 </h2>
+        <Form.Item<FieldType> valuePropName="checked" name="robot_ability_score_l2">
+          <Checkbox className='input_checkbox' />
+        </Form.Item>
+        <h2> L3 </h2>
+        <Form.Item<FieldType> valuePropName="checked" name="robot_ability_score_l3">
+          <Checkbox className='input_checkbox' />
+        </Form.Item>
+        <h2> L4 </h2>
+        <Form.Item<FieldType> valuePropName="checked" name="robot_ability_score_l4">
           <Checkbox className='input_checkbox' />
         </Form.Item>
         <h2>Climbing Capability</h2>

--- a/integrated-scouting-apps/src/routes/pit.tsx
+++ b/integrated-scouting-apps/src/routes/pit.tsx
@@ -7,11 +7,13 @@ import { useRef } from 'react';
 import { Button } from 'antd';
 import React, { useState, useEffect } from 'react';
 import back from '../public/images/back.png';
-import { ReactSketchCanvas, ReactSketchCanvasRef } from 'react-sketch-canvas';
+import { ReactSketchCanvasRef } from 'react-sketch-canvas';
 import VerifyLogin from '../verifyToken';
 import { useCookies } from 'react-cookie';
 import { saveAs } from 'file-saver';
 import TextArea from 'antd/es/input/TextArea';
+
+//Rhys was here//
 
 function PitScout(props: any) {
   const eventname = process.env.REACT_APP_EVENTNAME as string;

--- a/integrated-scouting-apps/src/routes/pit.tsx
+++ b/integrated-scouting-apps/src/routes/pit.tsx
@@ -294,9 +294,11 @@ function PitScout(props: any) {
           controls 
           className="input" 
           type="number"
+          value={formValue.robot_weight}
+          onChange={(value) => setFormValue({
+            ...formValue, robot_weight: value || 0})}
         />
         </Form.Item>
-
         <h2>Drive Train Type</h2>
         <Form.Item name="robot_drive_train" rules={[{ required: true, message: 'Please input the drive train type!' }]}>
         <Select

--- a/integrated-scouting-apps/src/routes/pit.tsx
+++ b/integrated-scouting-apps/src/routes/pit.tsx
@@ -108,7 +108,6 @@ function PitScout(props: any) {
       "robot_shooting_capability": event.robot_shooting_capability,
       "robot_ability_traversed_stage": event.robot_ability_traversed_stage,
       "robot_climbing_capabilities": event.robot_climbing_capabilities,
-      "robot_trap_detail": event.robot_trap_detail,
       "robot_pit_organization": event.robot_pit_organization,
       "robot_team_safety": event.robot_team_safety,
       "robot_team_workmanship": event.robot_team_workmanship,
@@ -135,7 +134,6 @@ function PitScout(props: any) {
       "robot_shooting_capability": "test",
       "robot_team_safety": -1,
       "robot_team_workmanship": -1,
-      "robot_trap_detail": "test",
       "robot_weight": -1,
       "robot_wheel_type": "test",
       "team_number": -1,
@@ -191,7 +189,6 @@ function PitScout(props: any) {
       robot_shooting_capability: string;
       robot_ability_traversed_stage: boolean;
       robot_climbing_capabilities: string;
-      robot_trap_detail: boolean;
       robot_pit_organization: number;
       robot_team_safety: number;
       robot_team_workmanship: number;
@@ -230,16 +227,16 @@ function PitScout(props: any) {
       { label: "None", value: 'none' },
     ];
     const shootingCap = [
-      { label: "Speaker", value: "speaker" },
-      { label: "Amp", value: "amp" },
+      { label: "Algae", value: "algae" },
+      { label: "Coral", value: "coral" },
       { label: "Both", value: 'both' },
       { label: "None", value: 'none' },
     ];
     const climbingCap = [
-      { label: "Solo Climb", value: "solo_climb" },
-      { label: "Harmonize", value: "harmonize" },
-      { label: "Triple Climb", value: 'triple_climb' },
-      { label: "No Climb", value: "no_climb" }
+      { label: "Shallow", value: "shallow" },
+      { label: "Deep", value: "deep" },
+      { label: "Parked", value: 'parked' },
+      { label: "None", value: "none" }
     ];
     return (
       <div>
@@ -299,10 +296,6 @@ function PitScout(props: any) {
         <h2>Climbing Capability</h2>
         <Form.Item<FieldType> name="robot_climbing_capabilities" rules={[{ required: true, message: 'Please input the climbing capability!' }]}>
           <Select options={climbingCap} className="input" />
-        </Form.Item>
-        <h2>Robot Trap</h2>
-        <Form.Item<FieldType> valuePropName="checked" name="robot_trap_detail">
-          <Checkbox className='input_checkbox' />
         </Form.Item>
         <h2>Auton Path</h2>
         <ReactSketchCanvas
@@ -452,9 +445,7 @@ function PitScout(props: any) {
       <Form
         form={form}
         initialValues={{
-          robot_ability_traversed_stage: false,
-          robot_trap_detail: false,
-        }}
+          robot_ability_traversed_stage: false,        }}
         onFinish={async (event) => {
           try {
             setLoading(true);


### PR DESCRIPTION
From top to down:
- Changed Team # to numbers only
- Moved Robot Weight from below Drive Train Type to above Drive Train Type
- Changed name from Robot Weight to Robot Weight (lbs)
- Changed name Shooting Capability to Coral Intake Capability
- Changed the options to 'Coral Station' 'Ground' 'Both' and 'None'
- Added 4 boolean boxes for L1 L2 L3 and L4 under the heading Coral Scoring
- Change box 'Intake Capability' to 'Algae Intake Capability'
- Changed the options to 'Reef Zone' 'Ground' 'Both' and 'None'
- Added another heading 'Algae Scoring Capability'
- Options include 'Net' 'Processor' 'Both' and 'None'
- Changed options in 'Climbing Capability' to 'Shallow' 'Deep' and 'None'
- Removed 'Parked' in 'Climbing Capability'
- Removed auton path
- Limited 'Pit Organization' 'Team Safety' 'Team Workmanship' and 'Gracious Professionalism' to (0-4)